### PR TITLE
Added support for env.json files

### DIFF
--- a/tapas-cli/index.js
+++ b/tapas-cli/index.js
@@ -13,6 +13,11 @@ const args = cli.parse({
   name: ["n", "Name of deployment", "string"],
   url: ["u", "URL to tapas service", "string", "localhost:3000"],
   version: ["v", "Increment Version", "string"],
+  env: [
+    "e",
+    "Include env file in deployment (accessible from ./env.json when deployed)",
+    "file",
+  ],
 });
 
 //Check for required variables
@@ -49,7 +54,7 @@ async function bundle() {
 async function upload() {
   console.log(chalk.cyan("Uploading..."));
   exec(
-    `curl -X POST -F 'name=${args.name}' -F 'version=${args.version}' -F 'file=@./${args.name}.tar.gz' ${args.url}/deployment`,
+    `curl -X POST -F 'name=${args.name}' -F 'version=${args.version}' -F 'file=@./${args.name}.tar.gz' -F 'env=@./${args.env}' ${args.url}/deployment`,
     function callback(error, stdout, stderr) {
       cli.info(stdout);
     }

--- a/tapas-service/src/index.js
+++ b/tapas-service/src/index.js
@@ -55,7 +55,6 @@ const init = async () => {
     method: "GET",
     path: "/",
     handler: (request, h) => {
-
       return `<!DOCTYPE html>
         <html lang="en">
         <head>
@@ -104,6 +103,13 @@ const init = async () => {
       );
       stream.on("finish", function () {
         extract(dir, req.payload.name);
+      });
+
+      const envStream = req.payload.env.pipe(
+        fs.createWriteStream(`${dir}env.json`)
+      );
+      envStream.on("finish", function () {
+        console.log("done writing env");
       });
 
       return `Deployed: http://${host}:${port}/${assetName}/${req.payload.name}/${next}/`;

--- a/tapas-ui/README.md
+++ b/tapas-ui/README.md
@@ -7,5 +7,5 @@ The UI is a dashboard for finding deployed applications, microfrontends, and web
 1. Have tapas-service running
 1. Have tapas-cli installed
 1. build tapas-ui `npm run build`
-1. Run `tapas-ui -n homepage -d ./public`
+1. Run `tapas-ui -n tapas-ui -d ./public -e exampleEnv.json`
 1. Go to http://localhost:3000/ and you should see the tapas-ui

--- a/tapas-ui/exampleEnv.json
+++ b/tapas-ui/exampleEnv.json
@@ -1,0 +1,5 @@
+{
+  "developer": "John Cudd",
+  "example": "Some custom value",
+  "example2": "Some custom value2"
+}

--- a/tapas-ui/src/App.svelte
+++ b/tapas-ui/src/App.svelte
@@ -1,7 +1,11 @@
 <script>
   import {onMount} from "svelte";
   import axios from "axios";
-  
+   let env= new Promise((resolve, reject)=>{
+    return axios.get('./env.json').then(results=>resolve(results.data));
+  });
+
+ 
   let packages = new Promise((resolve, reject)=>{
     return axios.get('http://localhost:3000/deployments').then(results=>resolve(results.data));
   });


### PR DESCRIPTION
This closes #4 
This lets the user add an environment file to their deployment which is handy if you have different settings for your app depending on where the app is deployed.

All env files are renamed to `env.json` and placed in the root of the deployment and can be accessed by the UI at anytime by fetching `env.json`