### PR TITLE
Watch and remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Deploy your Web Components, Microfrontends, and Single Page Apps all in one plac
 - Deployment versioning
 - Environmental Variable Support
 - Reverse Proxy for CORS support
+- Watch and deploy when files change
 - Dynamic Swagger Documentation (http://localhost:3000/documentation)
 - [manifest.json](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) files are used to display app information in the CastleBlock UI.
 - Deploy Single Page Apps, Microfrontends, Web Components, any Web Asset

--- a/castleblock-cli/README.md
+++ b/castleblock-cli/README.md
@@ -1,0 +1,26 @@
+# castleblock-cli
+
+The castleblock-cli interfaces with the castleblock-service API and deploys apps via a command line interface.
+
+## Usage
+
+```
+$ castleblock --help
+Welcome to the castleblock cli
+INFO: Type --help for list of parameters
+Usage:
+  castleblock [OPTIONS] [ARGS]
+
+Options:
+  -d, --directory FILE   Directory containing the built assets
+  -n, --name STRING      Name of deployment
+  -u, --url [STRING]     URL to castleblock service (Default is http://localhost:3000)
+  -v, --version STRING   Increment Version
+  -e, --env FILE         Include env file in deployment (accessible from
+                         ./env.json when deployed)
+  -w, --watch DIRECTORY  Watch the current directory, then build and deploy
+                         when a file changes.
+  -b, --build STRING     Build command that is run before deployment
+  -r, --remove           Remove deployment
+  -h, --help             Display help and usage details
+```

--- a/castleblock-cli/bin/castleblock
+++ b/castleblock-cli/bin/castleblock
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require = require('esm')(module /*, options*/);
+require('../index.js').start(process.argv);

--- a/castleblock-cli/index.js
+++ b/castleblock-cli/index.js
@@ -1,18 +1,19 @@
-#!/usr/bin/env node
-
-var cli = require("cli");
-var chalk = require("chalk");
-var fs = require("fs");
-var tar = require("tar");
-var path = require("path");
-var axios = require("axios");
-var FormData = require("form-data");
+import cli from "cli";
+import chalk from "chalk";
+import fs from "fs";
+import tar from "tar";
+import path from "path";
+import axios from "axios";
+import FormData from "form-data";
+import chokidar from "chokidar";
+import childProcess from "child_process";
+import { nanoid } from "nanoid";
 
 console.log(chalk.bold(chalk.cyan("Welcome to the castleblock cli")));
 cli.info("Type --help for list of parameters");
 
 const args = cli.parse({
-  directory: ["d", "Directory containing your built assets", "file"],
+  directory: ["d", "Directory containing the built assets", "file"],
   name: ["n", "Name of deployment", "string"],
   url: ["u", "URL to castleblock service", "string", "http://localhost:3000"],
   version: ["v", "Increment Version", "string"],
@@ -21,23 +22,45 @@ const args = cli.parse({
     "Include env file in deployment (accessible from ./env.json when deployed)",
     "file",
   ],
+  watch: [
+    "w",
+    "Watch the current directory, then build and deploy when a file changes.",
+    "directory",
+  ],
+  build: ["b", "Build command that is run before deployment", "string"],
+  remove: ["r", "Remove deployment"],
 });
 
 //Check for required variables
 
-if (!args.name) {
+if (!args.name && !args.watch) {
   cli.error(
     'Please include a name for your deployment. i.e. --name "my-deployment"'
   );
   process.exit(1);
 }
-if (!args.directory) {
+if (!args.directory && !args.remove) {
   cli.error(
     'Please include a directory to your build assets i.e. --directory"./build"'
   );
   process.exit(1);
 }
 
+const execWithPromise = async (command) => {
+  return new Promise(async (resolve, reject) => {
+    try {
+      resolve(childProcess.execSync(command));
+    } catch (error) {
+      reject(error);
+    }
+  });
+};
+
+async function build() {
+  if (args.build) {
+    return await execWithPromise(args.build);
+  }
+}
 async function bundle() {
   return new Promise((resolve, reject) => {
     console.log(chalk.cyan("Packaging..."));
@@ -79,10 +102,60 @@ async function upload() {
     .catch((error) => cli.error(error));
 }
 
+async function remove() {
+  console.log("Deleting Deployment");
+  await axios
+    .delete(
+      `${args.url}/deployment/${args.name}${
+        args.version ? `/${args.version}` : ""
+      }`
+    )
+    .then((response) => {
+      cli.info(response.data);
+    })
+    .catch((error) => cli.error(error));
+}
+
+function watch() {
+  // One-liner for current directory
+
+  console.log(`${chalk.bold("Watching")}: ${args.watch} for changes.`);
+  args.name = nanoid(10);
+
+  args.version = "0.0.1";
+  chokidar
+    .watch(args.watch, {
+      ignoreInitial: true,
+      ignored: [`${args.directory}`], // ignore dotfiles
+    })
+    .on("all", async (event, path) => {
+      await build();
+      await bundle();
+      await upload();
+      console.log(event, path);
+    });
+}
+
 console.log(`${chalk.bold("Name")}: ${chalk.cyan(args.name)}`);
 console.log(`${chalk.bold("Package")}: ${chalk.cyan(args.directory)}`);
 
-(async function () {
-  await bundle();
-  upload();
-})();
+export async function start(argv) {
+  process.on("SIGINT", async function () {
+    console.log("Caught interrupt signal");
+    if (args.watch) {
+      await remove();
+    }
+    process.exit();
+  });
+  if (args.remove) {
+    await remove();
+  } else if (args.watch) {
+    //Watch for changes
+    watch();
+  } else {
+    //Package and Deploy
+    await build();
+    await bundle();
+    await upload();
+  }
+}

--- a/castleblock-cli/package-lock.json
+++ b/castleblock-cli/package-lock.json
@@ -12,6 +12,15 @@
         "color-convert": "^2.0.1"
       }
     },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -30,6 +39,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -39,6 +53,14 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "chalk": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -46,6 +68,21 @@
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       }
     },
     "chownr": {
@@ -88,15 +125,36 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "requires": {
+        "type-fest": "^1.0.1"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
     },
     "follow-redirects": {
       "version": "1.14.3",
@@ -126,6 +184,12 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -137,6 +201,14 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "has-flag": {
@@ -157,6 +229,32 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "mime-db": {
       "version": "1.49.0",
@@ -201,6 +299,16 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
+    "nanoid": {
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q=="
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -213,6 +321,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -234,6 +355,19 @@
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
       }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/castleblock-cli/package.json
+++ b/castleblock-cli/package.json
@@ -2,7 +2,12 @@
   "name": "castleblock",
   "version": "0.0.1",
   "description": "CLI Program for the CastleBlock service.",
-  "keywords": ["cli", "deployment", "microfrontends", "ui"],
+  "keywords": [
+    "cli",
+    "deployment",
+    "microfrontends",
+    "ui"
+  ],
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -17,11 +22,16 @@
   "dependencies": {
     "axios": "^0.21.1",
     "chalk": "^4.1.0",
+    "chokidar": "^3.5.2",
     "cli": "^1.0.1",
+    "crypto-random-string": "^4.0.0",
+    "esm": "^3.2.25",
     "form-data": "^3.0.1",
+    "nanoid": "^3.1.25",
     "tar": "^6.1.11"
   },
   "bin": {
-    "castleblock": "index.js"
-  }
+    "castleblock": "bin/castleblock"
+  },
+  "devDependencies": {}
 }

--- a/castleblock-service/src/index.js
+++ b/castleblock-service/src/index.js
@@ -193,6 +193,41 @@ const init = async () => {
   });
 
   server.route({
+    method: "DELETE",
+    path: `/deployment/{name}/{version?}`,
+    handler: (req) => {
+      console.log(
+        `REMOVING: ${req.params.name} version: ${req.params.version}`
+      );
+      if (req.params.version) {
+        //Remove specific version
+        fs.rmdirSync(`${directory}/${req.params.name}/${req.params.version}`, {
+          recursive: true,
+        });
+
+        //Remove parent directory if empty
+        if (fs.readdirSync(`${directory}/${req.params.name}`).length === 0) {
+          fs.rmdirSync(`${directory}/${req.params.name}`, {
+            recursive: true,
+          });
+        }
+      } else {
+        //Remove all versions
+        fs.rmdirSync(`${directory}/${req.params.name}`, {
+          recursive: true,
+        });
+      }
+
+      return `Removed ${req.params.name}`;
+    },
+    options: {
+      description: "Fetch UI assets",
+      notes: "Returns html, js, css, and other UI assets",
+      tags: ["api"],
+    },
+  });
+
+  server.route({
     method: "GET",
     path: `/${assetName}/{file*}`,
     handler: {

--- a/castleblock-ui/src/App.svelte
+++ b/castleblock-ui/src/App.svelte
@@ -27,7 +27,7 @@ let packages = new Promise((resolve, reject) => {
 </script>
 
 <svelte:head>
-  <title>Castleblock Dashboard</title>
+  <title>Castleblock Dashboard </title>
   <link rel="icon" href="favicon.png" type="image/png" />
 </svelte:head>
 


### PR DESCRIPTION
Now a developer can deploy their app into a temporary space automatically anytime they make a change to their web app. Here are some example uses.

The following will watch the `./src` directory for changes, run the `npm run build` command, and deploy to a temporary address. 
```
castleblock --watch ./src -b "npm run build"
```
After the user Ctrl+C the deployment will be removed.

This usecase is ideal for sharing changes with other developers in real-time.
