### PR TITLE
Added hot-reloading to adhoc deployments

### DIFF
--- a/castleblock-service/package-lock.json
+++ b/castleblock-service/package-lock.json
@@ -4871,6 +4871,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "susie": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/susie/-/susie-3.0.0.tgz",
+      "integrity": "sha512-cjo/RCZdReZeL4DxmXawmblCkmkSVSp+PjxHfYG5zbGrSLxLC6QDMniHeuAN4amtFhNJQ7P+LAyTKl3tvrbSDw=="
+    },
     "swagger-methods": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",

--- a/castleblock-service/package.json
+++ b/castleblock-service/package.json
@@ -34,6 +34,7 @@
     "random-word-slugs": "0.0.5",
     "semver": "^7.3.5",
     "slugify": "^1.6.0",
+    "susie": "^3.0.0",
     "tar": "^6.1.11",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
Now when you run `castleblock watch -d ./public/`  a hot-reloading client gets added to the app's index.html by the service and reloads the page when the adhoc deployment is reloaded. Server Side Events are used for this.