### PR TITLE
Add serviceBaseURLPath option for serving relative links behind a reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ With the `castleblock watch` command developers can do development work in the c
 - Deployment versioning using [Semantic Versioning](https://semver.org/)
 - [Environmental Variable Injection](./castleblock-cli#environmental-variable-injection)
 - [Ad hoc deployments](./castleblock-cli#ad-hoc-deployments)
-- Dynamic Swagger Documentation <http://localhost:3000/documentation>
+- Dynamic Swagger Documentation <http://localhost:3000/api>
 - [manifest.json](./castleblock-cli#manifest.json) files are used to display app information in the CastleBlock UI
 - [OAuth](https://github.com/greymatter-io/castleblock/tree/master/castleblock-service#authentication) support for many oauth [providers](https://hapi.dev/module/bell/providers) for user authentication.
 - [JWT](https://github.com/greymatter-io/castleblock/tree/master/castleblock-service#issuing-jwt-tokens) for authorization

--- a/castleblock-service/configuration.md
+++ b/castleblock-service/configuration.md
@@ -16,8 +16,10 @@
 
 - **`statusMonitorEnable`** (type: boolean) : Enables status monitor page at /status
   (default: `true`)
-- **`swaggerDocsEnable`** (type: boolean) : Enables swagger API documentation page at /documentation
+- **`swaggerDocsEnable`** (type: boolean) : Enables swagger API documentation page at /api
   (default: `true`)
+- **`serviceBaseURLPath`** (type: string) : The base URL path for the deployed CastleBlock service. Required if behind a reverse proxy.
+  (default: `"/"`)
 - **`assetPath`** (type: string) : Directory path where the webapp assets are stored on disk.
   (default: `./assets`)
 - **`homepage`** (type: string) : The app that should be displayed as the landing page for the service.

--- a/castleblock-service/src/plugins.js
+++ b/castleblock-service/src/plugins.js
@@ -12,8 +12,9 @@ import utils from "./utils.js";
 import settings from "./settings.js";
 export default async function setupPlugins(server) {
   await server.register([Inert, H2o2, Vision, susie]);
-  if (!settings.serviceBaseURLPath.endsWith("/")) {
-    settings.serviceBaseURLPath += "/"
+  let basePath = settings.basePath
+  if (!basePath.endsWith("/")) {
+    basePath += "/"
   }
   if (settings.swaggerDocsEnable) {
     await server.register([
@@ -27,10 +28,10 @@ export default async function setupPlugins(server) {
             description: "CastleBlock is a Web Hosting as a Service platform.",
           },
           grouping: "tags",
-          jsonPath: settings.serviceBaseURLPath + "swagger.json",
-          jsonRoutePath: "/swaggerui/swagger.json",
-          swaggerUIPath: settings.serviceBaseURLPath,
-          routesBasePath: "/swaggerui/"
+          jsonPath: basePath + "swagger.json",
+          jsonRoutePath: "/swagger.json",
+          swaggerUIPath: basePath,
+          routesBasePath: "/"
         },
       },
     ]);

--- a/castleblock-service/src/plugins.js
+++ b/castleblock-service/src/plugins.js
@@ -12,7 +12,9 @@ import utils from "./utils.js";
 import settings from "./settings.js";
 export default async function setupPlugins(server) {
   await server.register([Inert, H2o2, Vision, susie]);
-
+  if (!settings.serviceBaseURLPath.endsWith("/")) {
+    settings.serviceBaseURLPath += "/"
+  }
   if (settings.swaggerDocsEnable) {
     await server.register([
       {
@@ -25,6 +27,10 @@ export default async function setupPlugins(server) {
             description: "CastleBlock is a Web Hosting as a Service platform.",
           },
           grouping: "tags",
+          jsonPath: settings.serviceBaseURLPath + "swagger.json",
+          jsonRoutePath: "/swaggerui/swagger.json",
+          swaggerUIPath: settings.serviceBaseURLPath,
+          routesBasePath: "/swaggerui/"
         },
       },
     ]);

--- a/castleblock-service/src/routes.js
+++ b/castleblock-service/src/routes.js
@@ -235,7 +235,7 @@ export default [
               return {
                 name: deployment,
                 versions: utils.versions(deployment, settings.assetPath),
-                path: Path.join(settings.appsPath, deployment),
+                path: Path.join("/", settings.appsPath, deployment),
                 latestManifest: Path.join(
                   `${settings.appsPath}`,
                   `${deployment}`,
@@ -267,7 +267,11 @@ export default [
               return {
                 name: deployment,
                 versions: utils.versions(deployment, settings.assetPath),
-                path: Path.join(settings.basePath, settings.appsPath, deployment),
+                path: Path.join(
+                  settings.basePath,
+                  settings.appsPath,
+                  deployment
+                ),
                 latestManifest: Path.join(
                   settings.basePath,
                   settings.appsPath,
@@ -332,7 +336,12 @@ export default [
         let htmlFile = fs.readFileSync(pathToFile + "index.html");
         return utils.injectBasePath(
           htmlFile,
-          `${Path.join(settings.basePath, settings.appsPath, request.params.appName, v)}/`
+          `${Path.join(
+            settings.basePath,
+            settings.appsPath,
+            request.params.appName,
+            v
+          )}/`
         );
       }
 

--- a/castleblock-service/src/routes.js
+++ b/castleblock-service/src/routes.js
@@ -41,8 +41,9 @@ export default [
       let htmlFile = fs.readFileSync(homepagePath);
       return utils.injectBasePath(
         htmlFile,
-        `/${Path.join(
+        `${Path.join(
           settings.basePath,
+          settings.appsPath,
           settings.homepage,
           utils.latestVersion(settings.homepage, settings.assetPath)
         )}/`
@@ -156,7 +157,7 @@ export default [
       return {
         appPath: appPath,
         url: `http://${settings.host}:${settings.port}/${Path.join(
-          settings.basePath,
+          settings.appsPath,
           appPath
         )}`,
       };
@@ -179,7 +180,7 @@ export default [
   },
   {
     method: "DELETE",
-    path: `/${settings.basePath}/{name}/{version}/`,
+    path: `/${settings.appsPath}/{name}/{version}/`,
     handler: (req) => {
       console.debug("REMOVEING", req.params.name, req.params.version);
       adhoc.removeClients(req.params.name, req.params.version);
@@ -234,9 +235,9 @@ export default [
               return {
                 name: deployment,
                 versions: utils.versions(deployment, settings.assetPath),
-                path: `/${settings.basePath}/${deployment}`,
+                path: Path.join(settings.appsPath, deployment),
                 latestManifest: Path.join(
-                  `${settings.basePath}`,
+                  `${settings.appsPath}`,
                   `${deployment}`,
                   `${utils.latestVersion(deployment, settings.assetPath)}`,
                   "manifest.json"
@@ -266,11 +267,12 @@ export default [
               return {
                 name: deployment,
                 versions: utils.versions(deployment, settings.assetPath),
-                path: `/${settings.basePath}/${deployment}`,
+                path: Path.join(settings.basePath, settings.appsPath, deployment),
                 latestManifest: Path.join(
-                  `${settings.basePath}`,
-                  `${deployment}`,
-                  `${utils.latestVersion(deployment, settings.assetPath)}`,
+                  settings.basePath,
+                  settings.appsPath,
+                  deployment,
+                  utils.latestVersion(deployment, settings.assetPath),
                   "manifest.json"
                 ),
               };
@@ -288,7 +290,7 @@ export default [
   },
   {
     method: "GET",
-    path: `/${settings.basePath}/{file*}`,
+    path: `/${settings.appsPath}/{file*}`,
     handler: {
       directory: {
         path: Path.normalize(`${settings.assetPath}`),
@@ -305,7 +307,7 @@ export default [
 
   {
     method: ["GET", "DELETE"],
-    path: `/${settings.basePath}/{appName}/{version}`,
+    path: `/${settings.appsPath}/{appName}/{version}`,
     handler: (req, h) => {
       return h.redirect(`${req.path}/`).permanent();
     },
@@ -313,7 +315,7 @@ export default [
 
   {
     method: "GET",
-    path: `/${settings.basePath}/{appName}/{version}/{end*}`,
+    path: `/${settings.appsPath}/{appName}/{version}/{end*}`,
     handler: (request, h) => {
       const v =
         request.params.version == "latest"
@@ -322,7 +324,7 @@ export default [
 
       let pathToFile = request.path
         .substring(1)
-        .replace(settings.basePath, settings.assetPath)
+        .replace(settings.appsPath, settings.assetPath)
         .replace("latest", v);
 
       //if a directory is requested append index.html
@@ -330,7 +332,7 @@ export default [
         let htmlFile = fs.readFileSync(pathToFile + "index.html");
         return utils.injectBasePath(
           htmlFile,
-          `/${Path.join(settings.basePath, request.params.appName, v)}/`
+          `${Path.join(settings.basePath, settings.appsPath, request.params.appName, v)}/`
         );
       }
 
@@ -339,7 +341,7 @@ export default [
       });
     },
     options: {
-      description: `Fetch ${settings.basePath} assets for the latest version of the deployment`,
+      description: `Fetch ${settings.appsPath} assets for the latest version of the deployment`,
       tags: ["api"],
     },
   },

--- a/castleblock-service/src/settingsSchema.js
+++ b/castleblock-service/src/settingsSchema.js
@@ -35,9 +35,6 @@ const settingsSchema = Joi.object({
   swaggerDocsEnable: Joi.boolean()
     .default(true)
     .description("Enables swagger API documentation page at /api"),
-  serviceBaseURLPath: Joi.string()
-    .default("/")
-    .description("The base URL path for the deployed CastleBlock service. Required if behind a reverse proxy."),
   assetPath: Joi.string()
     .default("./assets")
     .description("Directory path where the webapp assets are stored on disk."),
@@ -47,8 +44,11 @@ const settingsSchema = Joi.object({
       "The app that should be displayed as the landing page for the service."
     ),
   basePath: Joi.string()
+    .default("/")
+    .description("The base relative path for the CastleBlock service. Required if behind a reverse proxy."),
+  appsPath: Joi.string()
     .default("ui")
-    .description("URL basepath where all apps are hosted under"),
+    .description("The relative path to where all apps are hosted under."),
   jwt: Joi.object({
     secret: Joi.string()
       .description("HS256 or HS512 Secret Key. Default is randomly generated.")

--- a/castleblock-service/src/settingsSchema.js
+++ b/castleblock-service/src/settingsSchema.js
@@ -34,7 +34,10 @@ const settingsSchema = Joi.object({
     .description("Enables status monitor page at /status"),
   swaggerDocsEnable: Joi.boolean()
     .default(true)
-    .description("Enables swagger API documentation page at /documentation"),
+    .description("Enables swagger API documentation page at /api"),
+  serviceBaseURLPath: Joi.string()
+    .default("/")
+    .description("The base URL path for the deployed CastleBlock service. Required if behind a reverse proxy."),
   assetPath: Joi.string()
     .default("./assets")
     .description("Directory path where the webapp assets are stored on disk."),

--- a/castleblock-ui/src/App.svelte
+++ b/castleblock-ui/src/App.svelte
@@ -55,7 +55,7 @@ onMount(() => {
       <a href="https://github.com/greymatter-io/castleblock#readme">Docs</a>
     </div>
     <div class="navbar-item">
-      <a href="/api">API</a>
+      <a href="{window.location.href}api">API</a>
     </div>
     <div class="navbar-item">
       <div class="buttons">

--- a/castleblock-ui/src/App.svelte
+++ b/castleblock-ui/src/App.svelte
@@ -8,13 +8,13 @@ import GettingStarted from "./GettingStarted.svelte";
 
 let packages = new Promise((resolve, reject) => {
   return axios
-    .get(`${window.location.origin}/apps`)
+    .get(`${window.location.href}apps`)
     .then((results) => resolve(results.data));
 });
 
 let webcomponents = new Promise((resolve, reject) => {
   return axios
-    .get(`${window.location.origin}/webcomponents`)
+    .get(`${window.location.href}webcomponents`)
     .then((results) => resolve(results.data));
 });
 let hash = window.location.hash;

--- a/castleblock-ui/src/Card.svelte
+++ b/castleblock-ui/src/Card.svelte
@@ -6,7 +6,7 @@ export let pack = {};
 onMount(() => {
   if (pack.latestManifest) {
     axios
-      .get(`${window.location.href}${pack.latestManifest.slice(1)}`)
+      .get(`${window.location.href}${pack.latestManifest}`)
       .then((results) => {
         title = results.data.name;
         description = results.data.description;

--- a/castleblock-ui/src/Card.svelte
+++ b/castleblock-ui/src/Card.svelte
@@ -6,7 +6,7 @@ export let pack = {};
 onMount(() => {
   if (pack.latestManifest) {
     axios
-      .get(`${window.location.origin}/${pack.latestManifest}`)
+      .get(`${window.location.href}${pack.latestManifest.slice(1)}`)
       .then((results) => {
         title = results.data.name;
         description = results.data.description;
@@ -27,7 +27,7 @@ export let icons;
           <img
             class="image is-96x96"
             alt="logo"
-            src="{`${window.location.origin}${pack.path}/latest/${
+            src="{`${window.location.href}${pack.path}/latest/${
               icons.reverse()[icons.length - 1].src
             }`}" />
         </div>
@@ -36,7 +36,7 @@ export let icons;
         <p class="title is-5">
           <a
             target="_blank"
-            href="{`${window.location.origin}${pack.path}/latest/`}"
+            href="{`${window.location.href}${pack.path}/latest/`}"
             >{title || pack.name}</a>
         </p>
         {#if description}
@@ -65,7 +65,7 @@ export let icons;
           {#each pack.versions.reverse() as version, i}
             <a
               target="_blank"
-              href="{`${window.location.origin}${pack.path}/${version}/`}"
+              href="{`${window.location.href}${pack.path}/${version}/`}"
               class="dropdown-item">
               {pack.name} - {version}
               {i == 0 ? "(latest)" : ""}

--- a/castleblock-ui/src/GettingStarted.svelte
+++ b/castleblock-ui/src/GettingStarted.svelte
@@ -42,7 +42,7 @@
     </pre>
           </li>
           <li>
-            Get a <a href="{window.location.origin}/token">token</a>.
+            Get a <a href="{window.location.href}token">token</a>.
           </li>
           <li>
             Deploy your app with castleblock


### PR DESCRIPTION
This adds a configuration option for specifying a base URL path in case the CastleBlock service is deployed behind a reverse proxy and served with some base path other than `/`. For now, this is only used in the Swagger UI served at `/api`.

For example, when deployed to a Grey Matter mesh, the default route from Grey Matter Edge will be `/services/castleblock/latest/`. In order for Swagger UI assets to be retrieved, the `serviceBaseURLPath` value must be `/services/castleblock/latest/` so that the assets are available at `/services/castleblock/latest/swaggerui/`.